### PR TITLE
🐞fixed - intent as null so getAction() undefined

### DIFF
--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
@@ -18,6 +18,7 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
 
   private final ReactApplicationContext reactContext;
   private ReceiveSharingIntentHelper receiveSharingIntentHelper;
+  private Intent oldIntent;
 
   public ReceiveSharingIntentModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -30,6 +31,7 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
   protected void onNewIntent(Intent intent) {
     Activity mActivity = getCurrentActivity();
     if(mActivity == null) { return; }
+    oldIntent = mActivity.getIntent();
     mActivity.setIntent(intent);
   }
 
@@ -40,7 +42,9 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
     if(mActivity == null) { return; }
     Intent intent = mActivity.getIntent();
     receiveSharingIntentHelper.sendFileNames(reactContext, intent, promise);
-    mActivity.setIntent(null);
+    if (oldIntent != null) {
+      mActivity.setIntent(oldIntent);
+    }  
   }
 
   @ReactMethod

--- a/src/ReceiveSharingIntent.ts
+++ b/src/ReceiveSharingIntent.ts
@@ -33,7 +33,7 @@ class ReceiveSharingIntentModule implements IReceiveSharingIntent {
     }
 
     clearReceivedFiles(){
-        this.isClear = true;
+        ReceiveSharingIntent.clearReceivedFiles();
     }
 
     


### PR DESCRIPTION
Fixes as mentioned in https://github.com/ajith-ab/react-native-receive-sharing-intent/issues/110#issuecomment-971612714